### PR TITLE
Run under gosu

### DIFF
--- a/Dockerfile-buildimage
+++ b/Dockerfile-buildimage
@@ -25,4 +25,4 @@ RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["/oauth2_proxy"]
+CMD ["/gosu", "nobody", "/oauth2_proxy"]


### PR DESCRIPTION
This changes the Docker image to run `oauth2_proxy` under `gosu`.  Previously, `gosu` was installed but not utilized.  Using it here allows the proxy to drop privileges.